### PR TITLE
Update main to 2024 PCBS ITC Learners and fix Hugo build

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -4,3 +4,4 @@ LEARNERS_GITHUB_REPO="https://github.com/iaeaorg/learners"
 LEARNERS_GITHUB_BRANCH="main-application"
 LEARNERS_ENABLE_NGINX_SUBSTITUTION=1
 # LEARNERS_BASE_URL="/custom-path" 
+HUGO_VERSION=0.111.3

--- a/docker/build-certs/Dockerfile
+++ b/docker/build-certs/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 # Install OpenSSL
 RUN apk update && \

--- a/docker/build-hugo/Dockerfile
+++ b/docker/build-hugo/Dockerfile
@@ -1,11 +1,39 @@
-# Base image
-FROM klakegg/hugo:0.111.3-ext-ubuntu
+# Build stage
+FROM docker.io/library/golang:alpine AS builder
 
-# Set the working directory in the container
+RUN apk add --no-cache \
+    curl \
+    gcc \
+    g++ \
+    musl-dev \
+    build-base \
+    libc6-compat
+
+ARG HUGO_VERSION
+ENV HUGO_VERSION=${HUGO_VERSION:-0.111.3}
+
+RUN mkdir $HOME/src && \
+    cd $HOME/src && \
+    curl -L https://github.com/gohugoio/hugo/archive/refs/tags/v${HUGO_VERSION}.tar.gz | tar -xz && \
+    cd "hugo-${HUGO_VERSION}" && \
+    go install --tags extended
+
+# Runtime stage
+FROM docker.io/library/golang:alpine
+
 WORKDIR /src
 
 # Install python and python-pip
-RUN apt update && apt install -y python3-pip python3 python3-click python3-yaml wget unzip
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    py3-click \
+    py3-yaml \
+    wget \
+    unzip
+
+# Copy Hugo binary from builder
+COPY --from=builder /go/bin/hugo /usr/local/bin/hugo
 
 # Copy the entrypoint script
 COPY entrypoint.sh /app/entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,8 +47,10 @@ services:
         networks:
             - learners
         depends_on:
-            - build-hugo
-            - build-certs
+            build-hugo:
+                condition: service_completed_successfully
+            build-certs:
+                condition: service_completed_successfully
 
     learners-frontend:
         build:

--- a/docker/learners-backend/Dockerfile
+++ b/docker/learners-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:3.9
+FROM docker.io/library/python:3.9
 
 # Set the working directory in the container
 WORKDIR /app
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y python3-pip
 
 # Repo info
 ARG LEARNERS_GITHUB_REPO
-ENV LEARNERS_GITHUB_REPO=${LEARNERS_GITHUB_REPO:-https://github.com/ait-cs-IaaS/learners}
+ENV LEARNERS_GITHUB_REPO=${LEARNERS_GITHUB_REPO:-https://github.com/iaeaorg/learners}
 ARG LEARNERS_GITHUB_BRANCH
-ENV LEARNERS_GITHUB_BRANCH=${LEARNERS_GITHUB_BRANCH:-feature/drawio_integration}
+ENV LEARNERS_GITHUB_BRANCH=${LEARNERS_GITHUB_BRANCH:-main-application}
 
 # Install backend via git
 RUN pip3 install $LEARNERS_GITHUB_REPO/archive/refs/heads/$LEARNERS_GITHUB_BRANCH.zip

--- a/docker/learners-frontend/Dockerfile
+++ b/docker/learners-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:19 as build-stage
+FROM docker.io/library/node:19 as build-stage
 
 # Set the working directory in the container
 WORKDIR /app
@@ -31,7 +31,7 @@ RUN yarn install
 RUN yarn build
 
 # Use Nginx as the web server for serving the built Vue app
-FROM nginx:stable-alpine as production-stage
+FROM docker.io/library/nginx:stable-alpine as production-stage
 
 # Copy the built app from previous stage
 COPY --from=build-stage /app/frontend/dist /usr/share/nginx/html


### PR DESCRIPTION
This rebases Learners to the version worked on by myself as the IAEA Scientific Secretary and AIT during the International Training Course on Protecting Computer Based Systems in Nuclear Security Regimes hosted in Idaho Falls, USA in June 2024.

It is a rather extensive update that covers developments on Learners over the proceeding time between the publication in the IAEAOrg namespace and the course, and integrates modifications to Learners made as agreed in CRA Contract 24428 AUS.

In addition I have created a new Dockerfile for build-hugo that alleviates the dependency on outdated versions of ubuntu and fully qualified all docker image names.